### PR TITLE
Fix StrafeUI settings persistence

### DIFF
--- a/Plugins/StrafeUI/Source/StrafeUI/Private/S_UI_Settings.cpp
+++ b/Plugins/StrafeUI/Source/StrafeUI/Private/S_UI_Settings.cpp
@@ -3,3 +3,22 @@
 
 #include "S_UI_Settings.h"
 
+void US_UI_Settings::PostInitProperties()
+{
+    Super::PostInitProperties();
+
+    // Ensure settings are loaded from config files
+    LoadConfig();
+}
+
+#if WITH_EDITOR
+void US_UI_Settings::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
+{
+    Super::PostEditChangeProperty(PropertyChangedEvent);
+
+    // Persist the updated setting immediately
+    SaveConfig();
+}
+#endif
+
+

--- a/Plugins/StrafeUI/Source/StrafeUI/Public/S_UI_Settings.h
+++ b/Plugins/StrafeUI/Source/StrafeUI/Public/S_UI_Settings.h
@@ -116,4 +116,10 @@ public:
     UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Input")
     TSoftObjectPtr<UInputAction> BackAction;
     //~ End Input Settings
+
+    //~ UDeveloperSettings
+#if WITH_EDITOR
+    virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+#endif
+    virtual void PostInitProperties() override;
 };


### PR DESCRIPTION
## Summary
- persist UI developer settings across editor restarts by saving when edited
- reload saved config during initialization

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68456562e50c8331a35caff7f15e0361